### PR TITLE
dependabot/npm and yarn/vitest 0.32.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
                 "prettier": "^2.8.8",
                 "supabase": "^1.68.6",
                 "typescript": "^5.1.3",
-                "vitest": "0.31.4"
+                "vitest": "0.32.0"
             }
         },
         "node_modules/@adobe/css-tools": {
@@ -2013,13 +2013,13 @@
             }
         },
         "node_modules/@vitest/expect": {
-            "version": "0.31.4",
-            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.31.4.tgz",
-            "integrity": "sha512-tibyx8o7GUyGHZGyPgzwiaPaLDQ9MMuCOrc03BYT0nryUuhLbL7NV2r/q98iv5STlwMgaKuFJkgBW/8iPKwlSg==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.32.0.tgz",
+            "integrity": "sha512-VxVHhIxKw9Lux+O9bwLEEk2gzOUe93xuFHy9SzYWnnoYZFYg1NfBtnfnYWiJN7yooJ7KNElCK5YtA7DTZvtXtg==",
             "dev": true,
             "dependencies": {
-                "@vitest/spy": "0.31.4",
-                "@vitest/utils": "0.31.4",
+                "@vitest/spy": "0.32.0",
+                "@vitest/utils": "0.32.0",
                 "chai": "^4.3.7"
             },
             "funding": {
@@ -2027,12 +2027,12 @@
             }
         },
         "node_modules/@vitest/runner": {
-            "version": "0.31.4",
-            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.31.4.tgz",
-            "integrity": "sha512-Wgm6UER+gwq6zkyrm5/wbpXGF+g+UBB78asJlFkIOwyse0pz8lZoiC6SW5i4gPnls/zUcPLWS7Zog0LVepXnpg==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.32.0.tgz",
+            "integrity": "sha512-QpCmRxftHkr72xt5A08xTEs9I4iWEXIOCHWhQQguWOKE4QH7DXSKZSOFibuwEIMAD7G0ERvtUyQn7iPWIqSwmw==",
             "dev": true,
             "dependencies": {
-                "@vitest/utils": "0.31.4",
+                "@vitest/utils": "0.32.0",
                 "concordance": "^5.0.4",
                 "p-limit": "^4.0.0",
                 "pathe": "^1.1.0"
@@ -2069,9 +2069,9 @@
             }
         },
         "node_modules/@vitest/snapshot": {
-            "version": "0.31.4",
-            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.31.4.tgz",
-            "integrity": "sha512-LemvNumL3NdWSmfVAMpXILGyaXPkZbG5tyl6+RQSdcHnTj6hvA49UAI8jzez9oQyE/FWLKRSNqTGzsHuk89LRA==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.32.0.tgz",
+            "integrity": "sha512-yCKorPWjEnzpUxQpGlxulujTcSPgkblwGzAUEL+z01FTUg/YuCDZ8dxr9sHA08oO2EwxzHXNLjQKWJ2zc2a19Q==",
             "dev": true,
             "dependencies": {
                 "magic-string": "^0.30.0",
@@ -2115,9 +2115,9 @@
             "dev": true
         },
         "node_modules/@vitest/spy": {
-            "version": "0.31.4",
-            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.31.4.tgz",
-            "integrity": "sha512-3ei5ZH1s3aqbEyftPAzSuunGICRuhE+IXOmpURFdkm5ybUADk+viyQfejNk6q8M5QGX8/EVKw+QWMEP3DTJDag==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.32.0.tgz",
+            "integrity": "sha512-MruAPlM0uyiq3d53BkwTeShXY0rYEfhNGQzVO5GHBmmX3clsxcWp79mMnkOVcV244sNTeDcHbcPFWIjOI4tZvw==",
             "dev": true,
             "dependencies": {
                 "tinyspy": "^2.1.0"
@@ -2127,9 +2127,9 @@
             }
         },
         "node_modules/@vitest/utils": {
-            "version": "0.31.4",
-            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.31.4.tgz",
-            "integrity": "sha512-DobZbHacWznoGUfYU8XDPY78UubJxXfMNY1+SUdOp1NsI34eopSA6aZMeaGu10waSOeYwE8lxrd/pLfT0RMxjQ==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.32.0.tgz",
+            "integrity": "sha512-53yXunzx47MmbuvcOPpLaVljHaeSu1G2dHdmy7+9ngMnQIkBQcvwOcoclWFnxDMxFbnq8exAfh3aKSZaK71J5A==",
             "dev": true,
             "dependencies": {
                 "concordance": "^5.0.4",
@@ -2755,9 +2755,9 @@
             }
         },
         "node_modules/concordance/node_modules/semver": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-            "integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+            "version": "7.5.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.2.tgz",
+            "integrity": "sha512-SoftuTROv/cRjCze/scjGyiDtcUyxw1rgYQSZY7XTmtR5hX+dm76iDbTH8TkLPHCQmlbQVSSbNZCPM2hb0knnQ==",
             "dev": true,
             "dependencies": {
                 "lru-cache": "^6.0.0"
@@ -7400,9 +7400,9 @@
             }
         },
         "node_modules/vite-node": {
-            "version": "0.31.4",
-            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.31.4.tgz",
-            "integrity": "sha512-uzL377GjJtTbuc5KQxVbDu2xfU/x0wVjUtXQR2ihS21q/NK6ROr4oG0rsSkBBddZUVCwzfx22in76/0ZZHXgkQ==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.32.0.tgz",
+            "integrity": "sha512-220P/y8YacYAU+daOAqiGEFXx2A8AwjadDzQqos6wSukjvvTWNqleJSwoUn0ckyNdjHIKoxn93Nh1vWBqEKr3Q==",
             "dev": true,
             "dependencies": {
                 "cac": "^6.7.14",
@@ -7451,19 +7451,19 @@
             }
         },
         "node_modules/vitest": {
-            "version": "0.31.4",
-            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.31.4.tgz",
-            "integrity": "sha512-GoV0VQPmWrUFOZSg3RpQAPN+LPmHg2/gxlMNJlyxJihkz6qReHDV6b0pPDcqFLNEPya4tWJ1pgwUNP9MLmUfvQ==",
+            "version": "0.32.0",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.32.0.tgz",
+            "integrity": "sha512-SW83o629gCqnV3BqBnTxhB10DAwzwEx3z+rqYZESehUB+eWsJxwcBQx7CKy0otuGMJTYh7qCVuUX23HkftGl/Q==",
             "dev": true,
             "dependencies": {
                 "@types/chai": "^4.3.5",
                 "@types/chai-subset": "^1.3.3",
                 "@types/node": "*",
-                "@vitest/expect": "0.31.4",
-                "@vitest/runner": "0.31.4",
-                "@vitest/snapshot": "0.31.4",
-                "@vitest/spy": "0.31.4",
-                "@vitest/utils": "0.31.4",
+                "@vitest/expect": "0.32.0",
+                "@vitest/runner": "0.32.0",
+                "@vitest/snapshot": "0.32.0",
+                "@vitest/spy": "0.32.0",
+                "@vitest/utils": "0.32.0",
                 "acorn": "^8.8.2",
                 "acorn-walk": "^8.2.0",
                 "cac": "^6.7.14",
@@ -7479,7 +7479,7 @@
                 "tinybench": "^2.5.0",
                 "tinypool": "^0.5.0",
                 "vite": "^3.0.0 || ^4.0.0",
-                "vite-node": "0.31.4",
+                "vite-node": "0.32.0",
                 "why-is-node-running": "^2.2.2"
             },
             "bin": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
                 "@types/react": "^18.2.12",
                 "@typescript-eslint/parser": "5.59.11",
                 "@vitejs/plugin-react": "4.0.0",
-                "@vitest/coverage-c8": "^0.32.0",
+                "@vitest/coverage-v8": "^0.32.2",
                 "c8": "^8.0.0",
                 "eslint": "^8.42.0",
                 "eslint-config-next": "^13.4.6",
@@ -1992,49 +1992,29 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
-        "node_modules/@vitest/coverage-c8": {
-            "version": "0.32.0",
-            "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.32.0.tgz",
-            "integrity": "sha512-FeTzRN5VCL7B6YTRK5ZPQO2iwJzl2x7/mTQ/2uEeKZatAYBtvczeAYnzSUhCPev7p99+5skxMQZwqVcFTrVCdg==",
+        "node_modules/@vitest/coverage-v8": {
+            "version": "0.32.2",
+            "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.32.2.tgz",
+            "integrity": "sha512-/+V3nB3fyeuuSeKxCfi6XmWjDIxpky7AWSkGVfaMjAk7di8igBwRsThLjultwIZdTDH1RAxpjmCXEfSqsMFZOA==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.1",
-                "c8": "^7.13.0",
+                "@bcoe/v8-coverage": "^0.2.3",
+                "istanbul-lib-coverage": "^3.2.0",
+                "istanbul-lib-report": "^3.0.0",
+                "istanbul-lib-source-maps": "^4.0.1",
+                "istanbul-reports": "^3.1.5",
                 "magic-string": "^0.30.0",
                 "picocolors": "^1.0.0",
-                "std-env": "^3.3.2"
+                "std-env": "^3.3.2",
+                "test-exclude": "^6.0.0",
+                "v8-to-istanbul": "^9.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
             },
             "peerDependencies": {
-                "vitest": ">=0.30.0 <1"
-            }
-        },
-        "node_modules/@vitest/coverage-c8/node_modules/c8": {
-            "version": "7.14.0",
-            "resolved": "https://registry.npmjs.org/c8/-/c8-7.14.0.tgz",
-            "integrity": "sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==",
-            "dev": true,
-            "dependencies": {
-                "@bcoe/v8-coverage": "^0.2.3",
-                "@istanbuljs/schema": "^0.1.3",
-                "find-up": "^5.0.0",
-                "foreground-child": "^2.0.0",
-                "istanbul-lib-coverage": "^3.2.0",
-                "istanbul-lib-report": "^3.0.0",
-                "istanbul-reports": "^3.1.4",
-                "rimraf": "^3.0.2",
-                "test-exclude": "^6.0.0",
-                "v8-to-istanbul": "^9.0.0",
-                "yargs": "^16.2.0",
-                "yargs-parser": "^20.2.9"
-            },
-            "bin": {
-                "c8": "bin/c8.js"
-            },
-            "engines": {
-                "node": ">=10.12.0"
+                "vitest": ">=0.32.0 <1"
             }
         },
         "node_modules/@vitest/expect": {
@@ -4980,6 +4960,20 @@
                 "node": ">=8"
             }
         },
+        "node_modules/istanbul-lib-source-maps": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+            "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+            "dev": true,
+            "dependencies": {
+                "debug": "^4.1.1",
+                "istanbul-lib-coverage": "^3.0.0",
+                "source-map": "^0.6.1"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/istanbul-reports": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.1.5.tgz",
@@ -6647,6 +6641,15 @@
                 "node": ">=8"
             }
         },
+        "node_modules/source-map": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+            "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-js": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -7327,11 +7330,10 @@
             }
         },
         "node_modules/v8-to-istanbul": {
-            "version": "9.0.1",
-            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.0.1.tgz",
-            "integrity": "sha512-74Y4LqY74kLE6IFyIjPtkSTWzUZmj8tdHT9Ii/26dvQ6K9Dl2NbEfj0XgU2sHCtKgt5VupqhlO/5aWuqS+IY1w==",
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
+            "integrity": "sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==",
             "dev": true,
-            "license": "ISC",
             "dependencies": {
                 "@jridgewell/trace-mapping": "^0.3.12",
                 "@types/istanbul-lib-coverage": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "prettier": "^2.8.8",
         "supabase": "^1.68.6",
         "typescript": "^5.1.3",
-        "vitest": "0.31.4"
+        "vitest": "0.32.0"
     },
     "prettier": {
         "trailingComma": "es5",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
         "@vercel/og": "^0.5.7",
         "date-fns": "^2.30.0",
         "i18next": "^22.5.1",
+        "jsdom": "^22.1.0",
         "next": "^13.4.6",
         "next-i18next": "^13.3.0",
         "ramda": "^0.29.0",
@@ -34,8 +35,7 @@
         "react-content-loader": "^6.2.1",
         "react-dom": "^18.2.0",
         "react-i18next": "^12.3.1",
-        "zustand": "^4.3.8",
-        "jsdom": "^22.1.0"
+        "zustand": "^4.3.8"
     },
     "devDependencies": {
         "@testing-library/jest-dom": "^5.16.5",
@@ -46,7 +46,7 @@
         "@types/react": "^18.2.12",
         "@typescript-eslint/parser": "5.59.11",
         "@vitejs/plugin-react": "4.0.0",
-        "@vitest/coverage-c8": "^0.32.0",
+        "@vitest/coverage-v8": "^0.32.2",
         "c8": "^8.0.0",
         "eslint": "^8.42.0",
         "eslint-config-next": "^13.4.6",


### PR DESCRIPTION
- chore(deps-dev): bump vitest from 0.31.4 to 0.32.0
- chore(deps): replace @vitest/coverage-c8 with v8
